### PR TITLE
ci: Fix artifact handling for GitHub Actions v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
- 
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
@@ -51,16 +51,16 @@ jobs:
         rm *.cs
         dotnet build -c Release
         cp bin\Release\netstandard2.0\uno.fonts.fluent.dll ../Fluent
-    
+
     - name: Pack
       run: |
         $adjustedPackageVersion="${{ steps.gitversion.outputs.semVer }}".ToLower();
         build/nuget.exe pack nuget/Fluent/Uno.Fonts.Fluent.nuspec -Version $adjustedPackageVersion -OutputDirectory ./artifacts
-        
-    - name: Upload Artifacts
+
+    - name: Upload Fluent Artifacts  # Changed to have unique name for artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: NuGet
+        name: NuGet-Fluent
         path: ./artifacts
 
   build_roboto:
@@ -73,7 +73,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
- 
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
@@ -108,10 +108,10 @@ jobs:
         $adjustedPackageVersion="${{ steps.gitversion.outputs.semVer }}".ToLower();
         msbuild nuget\Roboto\Uno.Fonts.Roboto\Uno.Fonts.Roboto.csproj -t:pack -p:Configuration=Release -p:PackageVersion=$adjustedPackageVersion -p:PackageOutputPath=artifacts
 
-    - name: Upload Artifacts
+    - name: Upload Roboto Artifacts  # Changed to have unique name for artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: NuGet
+        name: NuGet-Roboto
         path: nuget\Roboto\Uno.Fonts.Roboto\artifacts
 
   build_opensans:
@@ -124,7 +124,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
- 
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
@@ -147,10 +147,10 @@ jobs:
         $adjustedPackageVersion="${{ steps.gitversion.outputs.semVer }}".ToLower();
         dotnet pack nuget\OpenSans\Uno.Fonts.OpenSans\Uno.Fonts.OpenSans.csproj -c Release -p:PackageVersion=$adjustedPackageVersion -p:PackageOutputPath=artifacts
 
-    - name: Upload Artifacts
+    - name: Upload OpenSans Artifacts  # Changed to have unique name for artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: NuGet
+        name: NuGet-OpenSans
         path: nuget\OpenSans\Uno.Fonts.OpenSans\artifacts
 
   publish:
@@ -160,35 +160,47 @@ jobs:
     runs-on: windows-latest
     needs: [build_fluent, build_roboto, build_opensans]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
 
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: NuGet
-          path: artifacts
+    - name: Download Fluent Artifacts  # Adjusted to download specific artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: NuGet-Fluent
+        path: artifacts/fluent
 
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'
+    - name: Download Roboto Artifacts  # Adjusted to download specific artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: NuGet-Roboto
+        path: artifacts/roboto
 
-      - name: Setup SignClient
-        run: |
-          dotnet tool install --tool-path build SignClient
-      - name: SignClient
-        shell: pwsh
-        run: |
-          build\SignClient sign -i artifacts\*.nupkg -c build\SignClient.json -r "${{ secrets.UNO_PLATFORM_CODESIGN_USERNAME }}" -s "${{ secrets.UNO_PLATFORM_CODESIGN_SECRET }}" -n "Uno.Check" -d "Uno.Check" -u "https://github.com/unoplatform/uno.check"
-        
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: NuGet-Signed
-          path: ./artifacts
+    - name: Download OpenSans Artifacts  # Adjusted to download specific artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: NuGet-OpenSans
+        path: artifacts/opensans
 
-      - name: NuGet Push
-        shell: pwsh
-        run: |
-          dotnet nuget push artifacts\*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_ORG_API_KEY }}        
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+
+    - name: Setup SignClient
+      run: |
+        dotnet tool install --tool-path build SignClient
+    - name: SignClient
+      shell: pwsh
+      run: |
+        build\SignClient sign -i artifacts\*.nupkg -c build\SignClient.json -r "${{ secrets.UNO_PLATFORM_CODESIGN_USERNAME }}" -s "${{ secrets.UNO_PLATFORM_CODESIGN_SECRET }}" -n "Uno.Check" -d "Uno.Check" -u "https://github.com/unoplatform/uno.check"
+      
+    - name: Upload Signed Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: NuGet-Signed
+        path: ./artifacts
+
+    - name: NuGet Push
+      shell: pwsh
+      run: |
+        dotnet nuget push artifacts\*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_ORG_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,4 +203,4 @@ jobs:
     - name: NuGet Push
       shell: pwsh
       run: |
-        dotnet nuget push artifacts\*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_ORG_API_KEY }}
+        dotnet nuget push artifacts/**/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_ORG_API_KEY }}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Build or CI related changes


## What is the current behavior?

With latest change to update to download-artifact and upload-artifact to v4, only 1 artifact is now downloaded for the publication
**Related previous PR: [ci: Update download-artifact and upload-artifact to v4 #51](https://github.com/unoplatform/uno.fonts/pull/51)**

![image](https://github.com/user-attachments/assets/21a96338-6801-427b-bb42-b2ebd510df59)

## What is the new behavior?

- Updated artifact upload steps to assign unique names (NuGet-Fluent, NuGet-Roboto, NuGet-OpenSans) to address changes introduced in actions/upload-artifact@v4.
- Modified publish job to download artifacts by job-scoped names into separate directories (artifacts/fluent, artifacts/roboto, artifacts/opensans).
- Adjusted signing and pushing steps to ensure consistent handling of artifacts across jobs and publishing.

>[!NOTE]
> Related details:
> - https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
> - https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

