### PR TITLE
Version bump after 2.6 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.6-dev.{height}",
-  "versionHeightOffset": 86,
+  "version": "2.7-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION

This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/2.6, based on #61