### PR TITLE
ci: Move to dotnet-sign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
       shell: pwsh
         run: >
           ./sign code azure-key-vault
-          artifacts\NuGet\*.nupkg
+          artifacts\**\*.nupkg
           --publisher-name "Uno.Fonts"
           --description "Uno.Fonts"
           --description-url "https://github.com/${{ env.GITHUB_REPOSITORY }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,11 @@ jobs:
     if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}
     environment: NuGet
     runs-on: windows-latest
+    environment: PackageSign
+
+    permissions:
+      id-token: write # Required for requesting the JWT
+
     needs: [build_fluent, build_roboto, build_opensans]
     steps:
     - name: Checkout
@@ -166,16 +171,35 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '9.0.x'
 
-    - name: Setup SignClient
-      run: |
-        dotnet tool install --tool-path build SignClient
-    - name: SignClient
+    # Install the code signing tool
+    - name: Install Sign CLI tool
+      run: dotnet tool install --tool-path . sign --version 0.9.1-beta.25278.1
+
+    # Login to Azure using a ServicePrincipal configured to authenticate against a GitHub Action
+    - name: 'Az CLI login'
+      uses: azure/login@v1
+      with:
+        allow-no-subscriptions: true
+        client-id: ${{ secrets.SIGN_AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.SIGN_AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.SIGN_AZURE_SUBSCRIPTION_ID }}
+
+    # Run the signing command
+    - name: Sign artifacts
       shell: pwsh
-      run: |
-        build\SignClient sign -i artifacts/**/*.nupkg -c build\SignClient.json -r "${{ secrets.UNO_PLATFORM_CODESIGN_USERNAME }}" -s "${{ secrets.UNO_PLATFORM_CODESIGN_SECRET }}" -n "Uno.Check" -d "Uno.Check" -u "https://github.com/unoplatform/uno.check"
-      
+        run: >
+          ./sign code azure-key-vault
+          artifacts\NuGet\*.nupkg
+          --publisher-name "Uno.Fonts"
+          --description "Uno.Fonts"
+          --description-url "https://github.com/${{ env.GITHUB_REPOSITORY }}"
+          --azure-key-vault-managed-identity true
+          --azure-key-vault-url "${{ secrets.SIGN_KEY_VAULT_URL }}"
+          --azure-key-vault-certificate "${{ secrets.SIGN_KEY_VAULT_CERTIFICATE_ID }}"
+          --verbosity information
+
     - name: Upload Signed Artifacts
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## Description

Move to dotnet-sign and not use the legacy signing service anymore

