### PR TITLE
Version bump after 2.9 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.9-dev.{height}",
+  "version": "2.9",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.9-dev.{height}",
+  "version": "2.10-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/2.9, based on #71