### PR TITLE
ci: Fix nbgv versioning broken by runner-image drift

### DIFF
--- a/.github/actions/setup-nbgv/action.yml
+++ b/.github/actions/setup-nbgv/action.yml
@@ -1,0 +1,28 @@
+name: Setup NBGV
+description: >-
+  Install the org-standard pinned nbgv (3.6.139) and expose its SemVer2 as both a
+  step output and the NBGV_SemVer2 env var. Uninstalls any pre-installed nbgv first
+  so a newer runner-image build (which `dotnet tool update` refuses to downgrade and
+  which may target an unavailable .NET runtime) can't break versioning — i.e. robust
+  against hosted-runner image drift. Mirrors uno core's build/ci gitversion step.
+
+outputs:
+  SemVer2:
+    description: The NBGV SemVer2 version.
+    value: ${{ steps.nbgv.outputs.SemVer2 }}
+
+runs:
+  using: composite
+  steps:
+    - name: Version with NBGV
+      id: nbgv
+      shell: pwsh
+      run: |
+        $PSNativeCommandUseErrorActionPreference = $false
+        dotnet tool uninstall --global nbgv | Out-Host
+        dotnet tool install --global nbgv --version 3.6.139
+        if ($LASTEXITCODE -ne 0) { throw "nbgv install failed ($LASTEXITCODE)" }
+        $v = (nbgv get-version -f json | ConvertFrom-Json).SemVer2
+        "SemVer2=$v" >> $env:GITHUB_OUTPUT
+        "NBGV_SemVer2=$v" >> $env:GITHUB_ENV
+        Write-Host "NBGV SemVer2: $v"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,22 @@ jobs:
       with:
         dotnet-version: '9.0.100'
 
-    - uses: dotnet/nbgv@f088059084cb5d872e9d1a994433ca6440c2bf72 # v0.4.2
+    - name: Version with NBGV
       id: nbgv
-      with:
-        toolVersion: 3.6.139
-        setAllVars: true
+      shell: pwsh
+      run: |
+        # The hosted runner pre-installs a newer nbgv (targets a .NET runtime not set up
+        # here); the dotnet/nbgv action's `dotnet tool update` won't downgrade to our pinned
+        # build, so uninstall first then install the org-standard 3.6.139 (same approach as
+        # uno core's build/ci gitversion step). Robust against future runner-image drift.
+        $PSNativeCommandUseErrorActionPreference = $false
+        dotnet tool uninstall --global nbgv | Out-Host
+        dotnet tool install --global nbgv --version 3.6.139
+        if ($LASTEXITCODE -ne 0) { throw "nbgv install failed ($LASTEXITCODE)" }
+        $v = (nbgv get-version -f json | ConvertFrom-Json).SemVer2
+        "SemVer2=$v" >> $env:GITHUB_OUTPUT
+        "NBGV_SemVer2=$v" >> $env:GITHUB_ENV
+        Write-Host "NBGV SemVer2: $v"
 
     - name: Build Fluent Font
       run: |
@@ -73,11 +84,22 @@ jobs:
       with:
         dotnet-version: '9.0.100'
 
-    - uses: dotnet/nbgv@f088059084cb5d872e9d1a994433ca6440c2bf72 # v0.4.2
+    - name: Version with NBGV
       id: nbgv
-      with:
-        toolVersion: 3.6.139
-        setAllVars: true
+      shell: pwsh
+      run: |
+        # The hosted runner pre-installs a newer nbgv (targets a .NET runtime not set up
+        # here); the dotnet/nbgv action's `dotnet tool update` won't downgrade to our pinned
+        # build, so uninstall first then install the org-standard 3.6.139 (same approach as
+        # uno core's build/ci gitversion step). Robust against future runner-image drift.
+        $PSNativeCommandUseErrorActionPreference = $false
+        dotnet tool uninstall --global nbgv | Out-Host
+        dotnet tool install --global nbgv --version 3.6.139
+        if ($LASTEXITCODE -ne 0) { throw "nbgv install failed ($LASTEXITCODE)" }
+        $v = (nbgv get-version -f json | ConvertFrom-Json).SemVer2
+        "SemVer2=$v" >> $env:GITHUB_OUTPUT
+        "NBGV_SemVer2=$v" >> $env:GITHUB_ENV
+        Write-Host "NBGV SemVer2: $v"
 
     - name: Install Windows SDK (${{ env.WIN_SDK_VERSION }})
       shell: pwsh
@@ -118,11 +140,22 @@ jobs:
       with:
         dotnet-version: '9.0.100'
 
-    - uses: dotnet/nbgv@f088059084cb5d872e9d1a994433ca6440c2bf72 # v0.4.2
+    - name: Version with NBGV
       id: nbgv
-      with:
-        toolVersion: 3.6.139
-        setAllVars: true
+      shell: pwsh
+      run: |
+        # The hosted runner pre-installs a newer nbgv (targets a .NET runtime not set up
+        # here); the dotnet/nbgv action's `dotnet tool update` won't downgrade to our pinned
+        # build, so uninstall first then install the org-standard 3.6.139 (same approach as
+        # uno core's build/ci gitversion step). Robust against future runner-image drift.
+        $PSNativeCommandUseErrorActionPreference = $false
+        dotnet tool uninstall --global nbgv | Out-Host
+        dotnet tool install --global nbgv --version 3.6.139
+        if ($LASTEXITCODE -ne 0) { throw "nbgv install failed ($LASTEXITCODE)" }
+        $v = (nbgv get-version -f json | ConvertFrom-Json).SemVer2
+        "SemVer2=$v" >> $env:GITHUB_OUTPUT
+        "NBGV_SemVer2=$v" >> $env:GITHUB_ENV
+        Write-Host "NBGV SemVer2: $v"
 
     - name: Pack OpenSans Font
       run: |
@@ -151,11 +184,22 @@ jobs:
       with:
         dotnet-version: '9.0.100'
 
-    - uses: dotnet/nbgv@f088059084cb5d872e9d1a994433ca6440c2bf72 # v0.4.2
+    - name: Version with NBGV
       id: nbgv
-      with:
-        toolVersion: 3.6.139
-        setAllVars: true
+      shell: pwsh
+      run: |
+        # The hosted runner pre-installs a newer nbgv (targets a .NET runtime not set up
+        # here); the dotnet/nbgv action's `dotnet tool update` won't downgrade to our pinned
+        # build, so uninstall first then install the org-standard 3.6.139 (same approach as
+        # uno core's build/ci gitversion step). Robust against future runner-image drift.
+        $PSNativeCommandUseErrorActionPreference = $false
+        dotnet tool uninstall --global nbgv | Out-Host
+        dotnet tool install --global nbgv --version 3.6.139
+        if ($LASTEXITCODE -ne 0) { throw "nbgv install failed ($LASTEXITCODE)" }
+        $v = (nbgv get-version -f json | ConvertFrom-Json).SemVer2
+        "SemVer2=$v" >> $env:GITHUB_OUTPUT
+        "NBGV_SemVer2=$v" >> $env:GITHUB_ENV
+        Write-Host "NBGV SemVer2: $v"
 
     - name: Install Windows SDK (${{ env.WIN_SDK_VERSION }})
       shell: pwsh
@@ -296,11 +340,20 @@ jobs:
         with:
           dotnet-version: '9.0.100'
 
-      - uses: dotnet/nbgv@f088059084cb5d872e9d1a994433ca6440c2bf72 # v0.4.2
+      - name: Version with NBGV
         id: nbgv
-        with:
-          toolVersion: 3.6.139
-          setAllVars: true
+        shell: pwsh
+        run: |
+          # See build-job note: uninstall the runner's pre-installed nbgv, then install the
+          # org-standard pinned 3.6.139 so versioning is stable against runner-image drift.
+          $PSNativeCommandUseErrorActionPreference = $false
+          dotnet tool uninstall --global nbgv | Out-Host
+          dotnet tool install --global nbgv --version 3.6.139
+          if ($LASTEXITCODE -ne 0) { throw "nbgv install failed ($LASTEXITCODE)" }
+          $v = (nbgv get-version -f json | ConvertFrom-Json).SemVer2
+          "SemVer2=$v" >> $env:GITHUB_OUTPUT
+          "NBGV_SemVer2=$v" >> $env:GITHUB_ENV
+          Write-Host "NBGV SemVer2: $v"
 
       - name: Tag and push to GitHub
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,22 +31,8 @@ jobs:
       with:
         dotnet-version: '9.0.100'
 
-    - name: Version with NBGV
+    - uses: ./.github/actions/setup-nbgv
       id: nbgv
-      shell: pwsh
-      run: |
-        # The hosted runner pre-installs a newer nbgv (targets a .NET runtime not set up
-        # here); the dotnet/nbgv action's `dotnet tool update` won't downgrade to our pinned
-        # build, so uninstall first then install the org-standard 3.6.139 (same approach as
-        # uno core's build/ci gitversion step). Robust against future runner-image drift.
-        $PSNativeCommandUseErrorActionPreference = $false
-        dotnet tool uninstall --global nbgv | Out-Host
-        dotnet tool install --global nbgv --version 3.6.139
-        if ($LASTEXITCODE -ne 0) { throw "nbgv install failed ($LASTEXITCODE)" }
-        $v = (nbgv get-version -f json | ConvertFrom-Json).SemVer2
-        "SemVer2=$v" >> $env:GITHUB_OUTPUT
-        "NBGV_SemVer2=$v" >> $env:GITHUB_ENV
-        Write-Host "NBGV SemVer2: $v"
 
     - name: Build Fluent Font
       run: |
@@ -84,22 +70,8 @@ jobs:
       with:
         dotnet-version: '9.0.100'
 
-    - name: Version with NBGV
+    - uses: ./.github/actions/setup-nbgv
       id: nbgv
-      shell: pwsh
-      run: |
-        # The hosted runner pre-installs a newer nbgv (targets a .NET runtime not set up
-        # here); the dotnet/nbgv action's `dotnet tool update` won't downgrade to our pinned
-        # build, so uninstall first then install the org-standard 3.6.139 (same approach as
-        # uno core's build/ci gitversion step). Robust against future runner-image drift.
-        $PSNativeCommandUseErrorActionPreference = $false
-        dotnet tool uninstall --global nbgv | Out-Host
-        dotnet tool install --global nbgv --version 3.6.139
-        if ($LASTEXITCODE -ne 0) { throw "nbgv install failed ($LASTEXITCODE)" }
-        $v = (nbgv get-version -f json | ConvertFrom-Json).SemVer2
-        "SemVer2=$v" >> $env:GITHUB_OUTPUT
-        "NBGV_SemVer2=$v" >> $env:GITHUB_ENV
-        Write-Host "NBGV SemVer2: $v"
 
     - name: Install Windows SDK (${{ env.WIN_SDK_VERSION }})
       shell: pwsh
@@ -140,22 +112,8 @@ jobs:
       with:
         dotnet-version: '9.0.100'
 
-    - name: Version with NBGV
+    - uses: ./.github/actions/setup-nbgv
       id: nbgv
-      shell: pwsh
-      run: |
-        # The hosted runner pre-installs a newer nbgv (targets a .NET runtime not set up
-        # here); the dotnet/nbgv action's `dotnet tool update` won't downgrade to our pinned
-        # build, so uninstall first then install the org-standard 3.6.139 (same approach as
-        # uno core's build/ci gitversion step). Robust against future runner-image drift.
-        $PSNativeCommandUseErrorActionPreference = $false
-        dotnet tool uninstall --global nbgv | Out-Host
-        dotnet tool install --global nbgv --version 3.6.139
-        if ($LASTEXITCODE -ne 0) { throw "nbgv install failed ($LASTEXITCODE)" }
-        $v = (nbgv get-version -f json | ConvertFrom-Json).SemVer2
-        "SemVer2=$v" >> $env:GITHUB_OUTPUT
-        "NBGV_SemVer2=$v" >> $env:GITHUB_ENV
-        Write-Host "NBGV SemVer2: $v"
 
     - name: Pack OpenSans Font
       run: |
@@ -184,22 +142,8 @@ jobs:
       with:
         dotnet-version: '9.0.100'
 
-    - name: Version with NBGV
+    - uses: ./.github/actions/setup-nbgv
       id: nbgv
-      shell: pwsh
-      run: |
-        # The hosted runner pre-installs a newer nbgv (targets a .NET runtime not set up
-        # here); the dotnet/nbgv action's `dotnet tool update` won't downgrade to our pinned
-        # build, so uninstall first then install the org-standard 3.6.139 (same approach as
-        # uno core's build/ci gitversion step). Robust against future runner-image drift.
-        $PSNativeCommandUseErrorActionPreference = $false
-        dotnet tool uninstall --global nbgv | Out-Host
-        dotnet tool install --global nbgv --version 3.6.139
-        if ($LASTEXITCODE -ne 0) { throw "nbgv install failed ($LASTEXITCODE)" }
-        $v = (nbgv get-version -f json | ConvertFrom-Json).SemVer2
-        "SemVer2=$v" >> $env:GITHUB_OUTPUT
-        "NBGV_SemVer2=$v" >> $env:GITHUB_ENV
-        Write-Host "NBGV SemVer2: $v"
 
     - name: Install Windows SDK (${{ env.WIN_SDK_VERSION }})
       shell: pwsh
@@ -340,20 +284,8 @@ jobs:
         with:
           dotnet-version: '9.0.100'
 
-      - name: Version with NBGV
+      - uses: ./.github/actions/setup-nbgv
         id: nbgv
-        shell: pwsh
-        run: |
-          # See build-job note: uninstall the runner's pre-installed nbgv, then install the
-          # org-standard pinned 3.6.139 so versioning is stable against runner-image drift.
-          $PSNativeCommandUseErrorActionPreference = $false
-          dotnet tool uninstall --global nbgv | Out-Host
-          dotnet tool install --global nbgv --version 3.6.139
-          if ($LASTEXITCODE -ne 0) { throw "nbgv install failed ($LASTEXITCODE)" }
-          $v = (nbgv get-version -f json | ConvertFrom-Json).SemVer2
-          "SemVer2=$v" >> $env:GITHUB_OUTPUT
-          "NBGV_SemVer2=$v" >> $env:GITHUB_ENV
-          Write-Host "NBGV SemVer2: $v"
 
       - name: Tag and push to GitHub
         shell: pwsh


### PR DESCRIPTION
## Problem

All font build jobs (Fluent / Roboto / OpenSans / Inter) — and the tag step — fail at the `dotnet/nbgv` action ([example run](https://github.com/unoplatform/uno.fonts/actions/runs/30308312545)):

```
dotnet tool update -g nbgv --version 3.6.139
→ The requested version 3.6.139 is lower than existing version 3.10.91.   # downgrade refused
nbgv.exe get-version -f json
→ You must install or update .NET to run this application.
   Framework: 'Microsoft.NETCore.App', version '10.0.0'   # nbgv 3.10.91 needs .NET 10
   The following frameworks were found: 9.0.0             # job only set up .NET 9
→ ##[error]nbgv.exe failed with exit code 2147516566
```

**Root cause = hosted-runner image drift** (not `version.json` / any branch cut): the runner now pre-installs nbgv **3.10.91** (targets **.NET 10**); the `dotnet/nbgv` action does `dotnet tool update`, which **won't downgrade** to our pinned `3.6.139`; and the job provisions only **.NET 9** — so the leftover 3.10.91 can't launch.

## Fix

Replace the `dotnet/nbgv` action (all 5 uses) with a **single reusable local composite action** — `.github/actions/setup-nbgv` — that does the **org-standard uninstall-then-install of the pinned nbgv `3.6.139`** (same approach uno core and the ADO-pipeline repos use in `build/ci/templates/gitversion.yml`). Each job now just:

```yaml
- uses: ./.github/actions/setup-nbgv
  id: nbgv
```

The **uninstall-first** defeats the "won't downgrade" trap, so the pinned, runtime-compatible `3.6.139` is always used — robust against future image drift (a bump to nbgv 3.11 / .NET 11 won't matter). Centralizing it means the logic lives in one place instead of five copies (`ci.yml` drops ~73 lines).

The composite action re-emits exactly what the workflow consumes:
- `SemVer2` **step output** (declared `output`) → pack steps (`steps.nbgv.outputs.SemVer2`)
- `NBGV_SemVer2` **env var** (via `$GITHUB_ENV`, persists to the job) → tag step (`$env:NBGV_SemVer2`)

## Validation

- **Code review** + `yaml.safe_load` parse of `ci.yml` and `action.yml`; 0 remaining `dotnet/nbgv@` refs; all 5 jobs reference the composite action; every job checks out before it; consumer references (`SemVer2` / `NBGV_SemVer2`) preserved.
- Runtime validation is CI on this PR.

## Backport

Targets **`main`** (default). To be **backported to `release/stable/2.9` via Mergify** — that branch must publish the stable `Uno.Fonts.Inter` 2.9.x (Simple design theme typeface) for **6.6 SR2** (related to https://github.com/unoplatform/private/issues/1102).

## Note (org-wide)

The same fragile `dotnet/nbgv` action is used by other GHA repos — **uno.check, uno.resizetizer, uno.icu, uno.devtools.telemetry, uno.templates, Uno.Wasm.Bootstrap** — which will hit the identical failure on their next runs. The composite action here could be promoted to a shared/org action so they all reuse one fix.
